### PR TITLE
chore: update `release-please` configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "release-type": "node",
   "always-update": true,
   "packages": {
-    ".": {}
+    ".": {
+      "include-component-in-tag": false
+    }
   }
 }


### PR DESCRIPTION
Do not include component name in tags since we release a single package