### PR TITLE
chore: update Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @panz3r will be requested for review when someone 
+# opens a pull request.
+*       @panz3r

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
 version: 2
 updates:
-  - package-ecosystem: 'devcontainers'
-    directory: '/'
+  - package-ecosystem: "devcontainers"
+    directory: "/"
     schedule:
       interval: monthly
-    reviewers:
-      - 'panz3r'
 
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: monthly
-    reviewers:
-      - 'panz3r'
 
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: weekly
       day: tuesday
-    reviewers:
-      - 'panz3r'
     groups:
       oclif:
         patterns:


### PR DESCRIPTION
This PR applies the changes required to comply with new GitHub policies described here: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/